### PR TITLE
Add create component tab view

### DIFF
--- a/src/components/Comments/CreateComment/index.tsx
+++ b/src/components/Comments/CreateComment/index.tsx
@@ -1,7 +1,38 @@
 import React, { FunctionComponent } from "react";
+import Box from "@material-ui/core/Box";
+import Typography from "@material-ui/core/Typography";
+import TextareaAutosize from "@material-ui/core/TextareaAutosize";
+import Button from "@material-ui/core/Button";
+import TabViewIntroSection from "../../TabViewIntroSection";
+
+const createComponentEndpoints = ["POST /comments"];
+const createComponentHeading = "Create a comment";
+const createComponentSubtitle =
+  "The first step is to always create the comment.";
 
 const CreateComment: FunctionComponent = () => {
-  return <div>Comment Create Tab Panel</div>;
+  return (
+    <React.Fragment>
+      <TabViewIntroSection
+        endpoints={createComponentEndpoints}
+        heading={createComponentHeading}
+        subtitle={createComponentSubtitle}
+      ></TabViewIntroSection>
+      <Box mt={6}>
+        <Typography variant="body2" align="center" color="textSecondary">
+          What are you thinking about? Write it in the box below.
+        </Typography>
+      </Box>
+      <Box display="flex" flexDirection="column" mt={1}>
+        <TextareaAutosize rowsMin={5} rowsMax={5}></TextareaAutosize>
+      </Box>
+      <Box display="flex" flexDirection="column" alignItems="center" mt={2}>
+        <Button variant="contained" color="secondary">
+          Comment
+        </Button>
+      </Box>
+    </React.Fragment>
+  );
 };
 
 export default CreateComment;

--- a/src/components/TabViewIntroSection/index.tsx
+++ b/src/components/TabViewIntroSection/index.tsx
@@ -1,0 +1,37 @@
+import React, { FunctionComponent } from "react";
+import Box from "@material-ui/core/Box";
+import Typography from "@material-ui/core/Typography";
+
+type TabViewIntroSectionProps = {
+  endpoints: string[];
+  heading: string;
+  subtitle: string;
+};
+
+const TabViewIntroSection: FunctionComponent<TabViewIntroSectionProps> = ({
+  endpoints,
+  heading,
+  subtitle,
+}) => {
+  return (
+    <React.Fragment>
+      {endpoints.map((endpoint) => (
+        <Typography variant="body2" align="center" color="textSecondary">
+          {endpoint}
+        </Typography>
+      ))}
+      <Box mt={6}>
+        <Typography variant="h4" align="center">
+          {heading}
+        </Typography>
+      </Box>
+      <Box mt={2}>
+        <Typography variant="body1" align="center">
+          {subtitle}
+        </Typography>
+      </Box>
+    </React.Fragment>
+  );
+};
+
+export default TabViewIntroSection;

--- a/src/components/TabViewsContainer/TabPanel/index.tsx
+++ b/src/components/TabViewsContainer/TabPanel/index.tsx
@@ -24,8 +24,8 @@ const TabPanel: FunctionComponent<TabPanelProps> = ({
       {...other}
     >
       {value === index && (
-        <Box p={3}>
-          <Container>{children}</Container>
+        <Box p={2}>
+          <Container maxWidth="sm">{children}</Container>
         </Box>
       )}
     </div>

--- a/src/components/TabViewsContainer/index.tsx
+++ b/src/components/TabViewsContainer/index.tsx
@@ -43,6 +43,8 @@ const TabViewsContainer: FunctionComponent<TabViewsContainerProps> = ({
         <Tabs
           value={value}
           onChange={handleChange}
+          variant="scrollable"
+          scrollButtons="off"
           aria-label={`The tabs for the different ${tabLabels[0]
             .split(" ")[0]
             .toLowerCase()} functionalities.`}


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Resolves #2 

**description of Task to be completed?**

- Create a `TabViewIntroSection` component for the introductory text.
- Add a `TabViewIntroSection`, `TextareaAutoresize`, and `Button` for the `CreateComment` tab view.
- Make the tabs scrollable for small screens.
- Use a maximum width for the tab views.

**How should this be manually tested?**

- In your terminal, run `npm start`.
- On your browser, visit `localhost:3000/comments` and view the Comment Create tab.

**Any background context you want to provide?**

None

**Questions:**

None
