### PR TITLE
Hotfix gh pages route

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,5 @@
     "type": "git",
     "url": "git+https://github.com/microapidev/comment-microapi-demo.git"
   },
-  "homepage": "https://microapidev.github.io/comment-microapi-demo/"
+  "homepage": "https://microapidev.github.io/comment-microapi-demo"
 }

--- a/src/common/enums/comments-action-type.ts
+++ b/src/common/enums/comments-action-type.ts
@@ -5,6 +5,11 @@ enum CommentsActionType {
   FLAG_COMMENT,
   DELETE_COMMENT,
   RESET_STATE,
+  CREATE_REPLY,
+  UPDATE_REPLY,
+  VOTE_REPLY,
+  FLAG_REPLY,
+  DELETE_REPLY,
 }
 
 export default CommentsActionType;

--- a/src/common/enums/comments-action-type.ts
+++ b/src/common/enums/comments-action-type.ts
@@ -1,0 +1,10 @@
+enum CommentsActionType {
+  CREATE_COMMENT,
+  UPDATE_COMMENT,
+  VOTE_COMMENT,
+  FLAG_COMMENT,
+  DELETE_COMMENT,
+  RESET_STATE,
+}
+
+export default CommentsActionType;

--- a/src/common/enums/index.ts
+++ b/src/common/enums/index.ts
@@ -1,3 +1,4 @@
+import CommentsActionType from "./comments-action-type";
 import RoutePath from "./route-path";
 
-export { RoutePath };
+export { CommentsActionType, RoutePath };

--- a/src/common/models/comment.ts
+++ b/src/common/models/comment.ts
@@ -1,0 +1,4 @@
+// Direct representation of the Comment abject from the Comment API
+class Comment {}
+
+export default Comment;

--- a/src/common/models/comment.ts
+++ b/src/common/models/comment.ts
@@ -2,15 +2,15 @@
 class Comment {
   constructor(
     public commentId: string,
-    public refId: string,
     public ownerId: string,
     public content: string,
-    public origin: string,
     public numOfVotes: number,
     public numOfUpVotes: number,
     public numOfDownVotes: number,
     public numOfFlags: number,
-    public numOfReplies: number
+    public numOfReplies: number,
+    public refId?: string,
+    public origin?: string
   ) {}
 }
 

--- a/src/common/models/comment.ts
+++ b/src/common/models/comment.ts
@@ -1,4 +1,17 @@
 // Direct representation of the Comment abject from the Comment API
-class Comment {}
+class Comment {
+  constructor(
+    public commentId: string,
+    public refId: string,
+    public ownerId: string,
+    public content: string,
+    public origin: string,
+    public numOfVotes: number,
+    public numOfUpVotes: number,
+    public numOfDownVotes: number,
+    public numOfFlags: number,
+    public numOfReplies: number
+  ) {}
+}
 
 export default Comment;

--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -1,3 +1,5 @@
+import Comment from "./comment";
+import Reply from "./reply";
 import Route from "./route";
 
-export { Route };
+export { Comment, Reply, Route };

--- a/src/common/models/reply.ts
+++ b/src/common/models/reply.ts
@@ -1,4 +1,15 @@
 // Direct representation of the Reply abject from the Comment API
-class Reply {}
+class Reply {
+  constructor(
+    public replyId: string,
+    public commentId: string,
+    public ownerId: string,
+    public content: string,
+    public numOfVotes: number,
+    public numOfUpVotes: number,
+    public numOfDownVotes: number,
+    public numOfFlags: number
+  ) {}
+}
 
 export default Reply;

--- a/src/common/models/reply.ts
+++ b/src/common/models/reply.ts
@@ -1,0 +1,4 @@
+// Direct representation of the Reply abject from the Comment API
+class Reply {}
+
+export default Reply;

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -9,6 +9,7 @@ import Comments, { tabLabels as commentsTabLabels } from "../Comments/index";
 import Replies, { tabLabels as repliesTabLabels } from "../Replies/index";
 import theme from "../../theme";
 import useCurrentRoute from "../../hooks/useCurrentRoute";
+import { CommentsContextProvider } from "../../context/comments";
 import { RoutePath } from "../../common/enums";
 
 const useStyles = makeStyles((theme) => ({
@@ -47,19 +48,23 @@ function App() {
             <React.Fragment></React.Fragment>
           )}
         </CustomAppBar>
-        <Switch>
-          <Route exact path={RoutePath.Home}>
-            <Home />
-          </Route>
-          <Route path={RoutePath.Comments}>
-            <Comments
-              tabValueState={[commentsTabsValue, setCommentsTabsValue]}
-            />
-          </Route>
-          <Route path={RoutePath.Replies}>
-            <Replies tabValueState={[repliesTabsValue, setRepliesTabsValue]} />
-          </Route>
-        </Switch>
+        <CommentsContextProvider>
+          <Switch>
+            <Route exact path={RoutePath.Home}>
+              <Home />
+            </Route>
+            <Route path={RoutePath.Comments}>
+              <Comments
+                tabValueState={[commentsTabsValue, setCommentsTabsValue]}
+              />
+            </Route>
+            <Route path={RoutePath.Replies}>
+              <Replies
+                tabValueState={[repliesTabsValue, setRepliesTabsValue]}
+              />
+            </Route>
+          </Switch>
+        </CommentsContextProvider>
       </div>
     </ThemeProvider>
   );

--- a/src/components/Comments/index.tsx
+++ b/src/components/Comments/index.tsx
@@ -35,7 +35,11 @@ const Comments: FunctionComponent<CommentsProps> = ({ tabValueState }) => {
     <React.Fragment>
       {tabViews.map((element, index) => {
         return (
-          <TabPanel tabIndex={index} activeTabIndex={tabValueState[0]}>
+          <TabPanel
+            key={tabLabels[index]}
+            tabIndex={index}
+            activeTabIndex={tabValueState[0]}
+          >
             {element}
           </TabPanel>
         );

--- a/src/components/Replies/index.tsx
+++ b/src/components/Replies/index.tsx
@@ -35,7 +35,11 @@ const Replies: FunctionComponent<RepliesProps> = ({ tabValueState }) => {
     <React.Fragment>
       {tabViews.map((element, index) => {
         return (
-          <TabPanel tabIndex={index} activeTabIndex={tabValueState[0]}>
+          <TabPanel
+            key={tabLabels[index]}
+            tabIndex={index}
+            activeTabIndex={tabValueState[0]}
+          >
             {element}
           </TabPanel>
         );

--- a/src/components/StateFooter/index.tsx
+++ b/src/components/StateFooter/index.tsx
@@ -1,10 +1,20 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Box, Button } from "@material-ui/core";
+import { CommentsContext } from "../../context/comments";
+import { CommentsActionType } from "../../common/enums";
 
 const StateFooter = () => {
+  const [state, dispatch] = useContext(CommentsContext);
+
+  console.log(state);
+
   const handleViewState = (event: any) => {};
 
-  const handleResetState = (event: any) => {};
+  const handleResetState = (event: any) => {
+    dispatch({
+      type: CommentsActionType.RESET_STATE,
+    });
+  };
 
   return (
     <Box display="flex" justifyContent="space-between" p={2}>

--- a/src/context/comments/index.tsx
+++ b/src/context/comments/index.tsx
@@ -1,0 +1,65 @@
+import React, { FunctionComponent, createContext, useReducer } from "react";
+import { Comment } from "../../common/models";
+import { CommentsActionType } from "../../common/enums";
+import { mockComments } from "./mock";
+
+// State
+interface State {
+  comments: Comment[];
+}
+
+const initialState: State = {
+  comments: mockComments,
+};
+
+// Creat Context Object
+export const CommentsContext = createContext<
+  [State, React.Dispatch<{ type: CommentsActionType }>]
+>([initialState, () => null]);
+
+const reducer = (state: State, action: any) => {
+  switch (action.type) {
+    case CommentsActionType.CREATE_COMMENT:
+      console.log("Create Comment");
+      return state;
+
+    case CommentsActionType.UPDATE_COMMENT:
+      console.log("Update Comment");
+      return state;
+
+    case CommentsActionType.FLAG_COMMENT:
+      console.log("Flag Comment");
+      return state;
+
+    case CommentsActionType.VOTE_COMMENT:
+      console.log("Vote Comment");
+      return state;
+
+    case CommentsActionType.DELETE_COMMENT:
+      console.log("Delete Comment");
+      return state;
+
+    case CommentsActionType.RESET_STATE:
+      console.log("Reset State");
+      return state;
+
+    default:
+      throw new Error();
+  }
+};
+
+type CommentsContextProviderProps = {
+  children?: React.ReactNode;
+};
+// Create a provider for components to consume and subscribe to changes
+export const CommentsContextProvider: FunctionComponent<CommentsContextProviderProps> = ({
+  children,
+}) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <CommentsContext.Provider value={[state, dispatch]}>
+      {children}
+    </CommentsContext.Provider>
+  );
+};

--- a/src/context/comments/index.tsx
+++ b/src/context/comments/index.tsx
@@ -1,15 +1,17 @@
 import React, { FunctionComponent, createContext, useReducer } from "react";
-import { Comment } from "../../common/models";
+import { Comment, Reply } from "../../common/models";
 import { CommentsActionType } from "../../common/enums";
 import { mockComments } from "./mock";
 
 // State
 interface State {
   comments: Comment[];
+  replies: Reply[];
 }
 
 const initialState: State = {
   comments: mockComments,
+  replies: [],
 };
 
 // Creat Context Object
@@ -19,6 +21,7 @@ export const CommentsContext = createContext<
 
 const reducer = (state: State, action: any) => {
   switch (action.type) {
+    // Comments reducers
     case CommentsActionType.CREATE_COMMENT:
       console.log("Create Comment");
       return state;
@@ -42,6 +45,27 @@ const reducer = (state: State, action: any) => {
     case CommentsActionType.RESET_STATE:
       console.log("Reset State");
       return initialState;
+
+    // Replies reducers
+    case CommentsActionType.CREATE_REPLY:
+      console.log("Create Reply");
+      return state;
+
+    case CommentsActionType.UPDATE_REPLY:
+      console.log("Update Reply");
+      return state;
+
+    case CommentsActionType.FLAG_REPLY:
+      console.log("Flag Reply");
+      return state;
+
+    case CommentsActionType.VOTE_REPLY:
+      console.log("Vote Reply");
+      return state;
+
+    case CommentsActionType.DELETE_REPLY:
+      console.log("Delete Reply");
+      return state;
 
     default:
       throw new Error();

--- a/src/context/comments/index.tsx
+++ b/src/context/comments/index.tsx
@@ -41,7 +41,7 @@ const reducer = (state: State, action: any) => {
 
     case CommentsActionType.RESET_STATE:
       console.log("Reset State");
-      return state;
+      return initialState;
 
     default:
       throw new Error();

--- a/src/context/comments/mock.ts
+++ b/src/context/comments/mock.ts
@@ -1,3 +1,44 @@
 import { Comment } from "../../common/models";
 
-export const mockComments: Comment[] = [];
+export const mockComments: Comment[] = [
+  new Comment(
+    "1edd40c86762e0fb12000003",
+    "owner1@gmail.com",
+    "This is such a lovely day. #BeachParty",
+    95,
+    5,
+    90,
+    1,
+    4
+  ),
+  new Comment(
+    "2edd40c86762e0fb12000003",
+    "owner2@gmail.com",
+    "As some people just don't think. #BeachParty !== #SocialDistancing",
+    55,
+    53,
+    2,
+    0,
+    4
+  ),
+  new Comment(
+    "3edd40c86762e0fb12000003",
+    "owner3@gmail.com",
+    "2Africa will be a game changer for the African digital landscape.",
+    271,
+    255,
+    16,
+    0,
+    4
+  ),
+  new Comment(
+    "4edd40c86762e0fb12000003",
+    "owner4@gmail.com",
+    "Sony is gearing up to change the gaming industry for another generation.",
+    559,
+    372,
+    187,
+    0,
+    4
+  ),
+];

--- a/src/context/comments/mock.ts
+++ b/src/context/comments/mock.ts
@@ -1,0 +1,3 @@
+import { Comment } from "../../common/models";
+
+export const mockComments: Comment[] = [];

--- a/src/hooks/useCurrentRoute/index.ts
+++ b/src/hooks/useCurrentRoute/index.ts
@@ -7,6 +7,8 @@ const useCurrentRoute = () => {
   const location = useLocation();
 
   switch (location.pathname) {
+    // Route path from Github pages.
+    case "/comment-microapi-demo":
     case RoutePath.Home:
       return new Route(RoutePath.Home);
 


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes the error thrown on github pages due to the `useCurrentRoute` hook.

**description of Task to be completed?**

- Add the route path used by the github pages `/comment-microapi-demo` to the `useCurrentRoute` hook's switch statement.

**How should this be manually tested?**

N/A

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

None

**Questions:**

None
