### PR TITLE
[FIX] Blank replies tab views when no replies or comments exist in state.

### DIFF
--- a/src/components/StateFooter/index.tsx
+++ b/src/components/StateFooter/index.tsx
@@ -21,11 +21,11 @@ const StateFooter = () => {
 
   const handleViewState = () => setOpen(true);
 
-  const handleResetState = () => {
-    dispatch({
-      type: CommentsActionType.RESET_STATE,
-    });
-  };
+  // const handleResetState = () => {
+  //   dispatch({
+  //     type: CommentsActionType.RESET_STATE,
+  //   });
+  // };
 
   const handleOk = () => {
     if (state.isSelectedCommentDialogOpen) {
@@ -43,9 +43,10 @@ const StateFooter = () => {
     <div className={classes.root}>
       <Box display="flex" justifyContent="space-between" p={2}>
         <Button onClick={handleViewState}>View Current State</Button>
-        <Button onClick={handleResetState} disabled>
+        <div></div>
+        {/* <Button onClick={handleResetState} disabled>
           Reset State
-        </Button>
+        </Button> */}
       </Box>
       <Box>
         <CommentDialog

--- a/src/context/comments/index.tsx
+++ b/src/context/comments/index.tsx
@@ -205,17 +205,21 @@ const reducer = (state: State, action: any) => {
     case CommentsResultType.ADD_REPLIES: {
       const { commentId, replies } = action.payload;
 
-      replies.forEach((reply: Reply) => {
-        if (!replyExists(commentId, reply.replyId)) {
-          state.replies.push(reply);
-        }
-      });
+      if (commentId.length > 0) {
+        replies.forEach((reply: Reply) => {
+          if (!replyExists(commentId, reply.replyId)) {
+            state.replies.push(reply);
+          }
+        });
+      }
 
       const updatedState = {
         ...state,
         repliesLoaded: true,
         loading: false,
       };
+
+      console.log(action.payload);
 
       return updatedState;
     }

--- a/src/context/comments/middleware.ts
+++ b/src/context/comments/middleware.ts
@@ -45,11 +45,13 @@ const dispatchMiddleware = (dispatch: React.Dispatch<any>) => {
 
           const commentsReplies = await Promise.all(commentsRepliesPromises);
 
-          commentsReplies.forEach((commentReplies) => {
-            if (commentReplies.length > 0) {
+          if (commentsReplies.length > 0) {
+            commentsReplies.forEach((commentReplies) => {
               helper.addReplies(commentReplies[0].commentId, commentReplies);
-            }
-          });
+            });
+          } else {
+            helper.addReplies("", []);
+          }
 
           dispatch({
             type: CommentsResultType.SET_SELECTED_COMMENT,
@@ -120,7 +122,6 @@ const dispatchMiddleware = (dispatch: React.Dispatch<any>) => {
         try {
           const pageQuery = action.payload.pageQuery;
           const comments = await commentService.getAllComments(pageQuery);
-          console.log(comments);
           helper.addComments(comments);
           helper.setSelectedCommentDialogOpen(true);
         } catch (error) {

--- a/src/services/comment/index.ts
+++ b/src/services/comment/index.ts
@@ -2,7 +2,7 @@ import CommentSDK from "comments-microapi-sdk";
 import { Comment, Reply } from "../../common/models";
 
 const commentApplicationToken =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbklkIjoiNWYwZjUxZjcxYjZjOWYwMDFlYzEzZjg4IiwiYWRtaW5JZCI6IjVmMGY1MWJlMWI2YzlmMDAxZWMxM2Y4NyIsImlhdCI6MTU5NDgzOTU0MywiZXhwIjoxNTk3NDMxNTQzfQ.IbeXp7eBI1E9HleuC1YjkQPa2NrXJoiFX8Is2ZHa6_A"
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbklkIjoiNWYwZjUxZjcxYjZjOWYwMDFlYzEzZjg4IiwiYWRtaW5JZCI6IjVmMGY1MWJlMWI2YzlmMDAxZWMxM2Y4NyIsImlhdCI6MTU5NDgzOTU0MywiZXhwIjoxNTk3NDMxNTQzfQ.IbeXp7eBI1E9HleuC1YjkQPa2NrXJoiFX8Is2ZHa6_A";
 
 class CommentService {
   private sdkInstance: any;


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes a bug where the replies page's tab views would be blank if there was not at least one comment with a reply or no comments at all in the state.

**description of Task to be completed?**

- Ensure that the repliesLoaded state resolves to true with an empty array

**How should this be manually tested?**

- In your terminal, run `npm start`
- On your browser, visit localhost:3000/comment-microapi-demo/replies` and delete all replies.

**Any background context you want to provide?**
None

**What is the link to the issue on Github?**

None

**Questions:**

None
