### PR TITLE
[FIX] Handle empty replies arrays

### DIFF
--- a/src/context/comments/index.tsx
+++ b/src/context/comments/index.tsx
@@ -205,7 +205,7 @@ const reducer = (state: State, action: any) => {
     case CommentsResultType.ADD_REPLIES: {
       const { commentId, replies } = action.payload;
 
-      if (commentId.length > 0) {
+      if (commentId) {
         replies.forEach((reply: Reply) => {
           if (!replyExists(commentId, reply.replyId)) {
             state.replies.push(reply);
@@ -218,8 +218,6 @@ const reducer = (state: State, action: any) => {
         repliesLoaded: true,
         loading: false,
       };
-
-      console.log(action.payload);
 
       return updatedState;
     }

--- a/src/context/comments/middleware-helpers.ts
+++ b/src/context/comments/middleware-helpers.ts
@@ -50,7 +50,7 @@ class DispatchMiddlewareHelper {
     });
   }
 
-  addReplies(commentId: string, replies: Reply[]) {
+  addReplies(commentId: string | undefined, replies: Reply[]) {
     this.dispatch({
       type: CommentsResultType.ADD_REPLIES,
       payload: {

--- a/src/context/comments/middleware.ts
+++ b/src/context/comments/middleware.ts
@@ -17,7 +17,7 @@ let helper: DispatchMiddlewareHelper;
  */
 const dispatchMiddleware = (dispatch: React.Dispatch<any>) => {
   return async (action: any) => {
-    if (!helper) {
+    if (helper === undefined) {
       helper = new DispatchMiddlewareHelper(dispatch);
     }
 
@@ -46,11 +46,11 @@ const dispatchMiddleware = (dispatch: React.Dispatch<any>) => {
           const commentsReplies = await Promise.all(commentsRepliesPromises);
 
           if (commentsReplies.length > 0) {
-            commentsReplies.forEach((commentReplies) => {
-              helper.addReplies(commentReplies[0].commentId, commentReplies);
+            commentsReplies.forEach((replies) => {
+              helper.addReplies(replies[0]?.commentId, replies);
             });
           } else {
-            helper.addReplies("", []);
+            helper.addReplies(undefined, []);
           }
 
           dispatch({


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Some comments have no replies and thus would have an empty array. The code wasn't accounting for this. The fix ensures that in such cases, it is handled.

**description of Task to be completed?**

- Handle arrays with an empty array and an undefined commentId as a result.

**How should this be manually tested?**

- In your terminal, run `npm start`
- On your browser, visit `localhost:3000/replies`.

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

None

**Questions:**

None
